### PR TITLE
fix links and gulp installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ If everything went right you should see a button that will open a popup with sub
 Install requirements
 
     gem install sass
-    npm install gulp gulp-util gulp-coffee gulp-ruby-sass gulp-watch gulp-uglify gulp-concat uglify-js
+		npm install -g gulp
+    npm install gulp-util gulp-coffee gulp-ruby-sass gulp-watch gulp-uglify gulp-concat uglify-js
 
 Use gulp to build the project or start the watcher:
 
@@ -35,8 +36,8 @@ Use gulp to build the project or start the watcher:
 
 ## Contribution
 
-If you find a bug please use [Github Issues](https://github.com/benzimmer/podlove-subscribe-it/issues) to report it. If you want to add a feature or fix a bug please fork the repository, make your changes in a feature branch and open a pull-request.
+If you find a bug please use [Github Issues](https://github.com/podlove/podlove-subscribe-it/issues) to report it. If you want to add a feature or fix a bug please fork the repository, make your changes in a feature branch and open a pull-request.
 
 ## License
 
-[MIT](https://github.com/benzimmer/podlove-subscribe-it/blob/master/LICENSE)
+[MIT](https://github.com/podlove/podlove-subscribe-it/blob/master/LICENSE)


### PR DESCRIPTION
Links still pointed to original repo.
To be able to run gulp like described you'll need to install it globally ( or modify your `$PATH`).
