### PR TITLE
Encode feed URLs when client scheme includes query arguments

### DIFF
--- a/src/coffee/clients_panel.coffee
+++ b/src/coffee/clients_panel.coffee
@@ -51,13 +51,17 @@ class ClientsPanel extends Panel
 
   prepareClients: (pathPrefix) ->
     feed = @chooseFeed() || {}
-    feedUrlWithOutHttp = feed.url.replace(/^(http|https):\/\//, '')
     return false unless feed.url
+    feedUrlWithOutHttp = feed.url.replace(/^(http|https):\/\//, '')
 
     for client in @clients
       Utils.fixIconPath(client, pathPrefix)
 
-      standardUrl = "#{client.scheme}#{feedUrlWithOutHttp}"
+      standardUrl = if -1 == client.scheme.indexOf('?')
+        "#{client.scheme}#{feedUrlWithOutHttp}"
+      else
+        "#{client.scheme}#{encodeURIComponent(feedUrlWithOutHttp)}"
+
       client.url = if type = client.customFeedType
         if customUrl = feed["directory-url-#{type}"]
           customUrl
@@ -72,6 +76,11 @@ class ClientsPanel extends Panel
     for client in @cloudClients
       Utils.fixIconPath(client, pathPrefix)
       cloudFeedUrl = if client.http then feed.url else feedUrlWithOutHttp
+      cloudFeedUrl = if -1 == client.scheme.indexOf('?')
+        cloudFeedUrl
+      else
+        encodeURIComponent(cloudFeedUrl)
+
       if client.post
         client.url = client.scheme
         client.feedUrl = cloudFeedUrl


### PR DESCRIPTION
This resolves issue #148, making URLs with query parameters compatible with Overcast.

Code has been added to check if a client scheme includes a `?` and if so, applies URL encoding to the feed URL that is concatenated with the scheme. This is done for both normal and cloud clients. At the moment, there are only three clients in the `clients.coffee` file that this affects:

- `overcast://x-callback-url/add?url=`
- `http://gpodder.net/subscribe?url=`
- `https://player.fm/subscribe?id=`

I've tested this successfully with Overcast and gpodder.net. Player.fm on *Cloud* doesn't work with or without URL encoding, because the `id=` parameter doesn't accept a URL (see issue #150). Player.fm on Android I don't have access to.

I also moved this line up before `feed.url` is used: `return false unless feed.url`

It's possible that the other client schemes (the ones that don't use a query argument to pass the feed URL) will also need URL encoding, but I don't have access to any other than the Podcasts app on iOS, where the unencoded URL works fine. Do y'all have a test process setup for other clients?