### PR TITLE
Add support for pcast:// handler on linux

### DIFF
--- a/src/coffee/clients.coffee
+++ b/src/coffee/clients.coffee
@@ -30,6 +30,10 @@ class Clients
     windowsphone: {
       scheme: 'pcast:'
       icon: 'generic/windowsphone.png'
+    },
+    linux: {
+      scheme: 'pcast:'
+      icon: 'generic/rss.png'
     }
   }
 


### PR DESCRIPTION
Is there a reason that the pcast url handler is not used as default
for linux? It's rather easy to configure a url handler with the
freedesktop spec. That would be really useful for me as my own
client has just one user, and can't probably hope to be added to
podlove. :)