### PR TITLE
Remove store link for uPod

### DIFF
--- a/src/coffee/clients.coffee
+++ b/src/coffee/clients.coffee
@@ -110,7 +110,6 @@ class Clients
       title: 'uPod'
       scheme: 'upod://'
       icon: 'android/upod.png'
-      store: 'https://play.google.com/store/apps/details?id=mobi.upod.app'
     }
   ]
 


### PR DESCRIPTION
[uPod](https://play.google.com/store/apps/details?id=mobi.upod.app) is no longer available on Google Play.