### PR TITLE
Keep original scheme for Overcast

### DIFF
--- a/src/coffee/clients.coffee
+++ b/src/coffee/clients.coffee
@@ -143,6 +143,7 @@ class Clients
       scheme: 'overcast://x-callback-url/add?url='
       icon: 'ios/overcast.png'
       store: 'https://itunes.apple.com/de/app/overcast-podcast-player/id888422857'
+      http: true
     },
     {
       title: 'PocketCasts'

--- a/src/coffee/clients_panel.coffee
+++ b/src/coffee/clients_panel.coffee
@@ -57,7 +57,8 @@ class ClientsPanel extends Panel
     for client in @clients
       Utils.fixIconPath(client, pathPrefix)
 
-      standardUrl = "#{client.scheme}#{feedUrlWithOutHttp}"
+      feedUrl = if client.http then feed.url else feedUrlWithOutHttp
+      standardUrl = "#{client.scheme}#{feedUrl}"
       client.url = if type = client.customFeedType
         if customUrl = feed["directory-url-#{type}"]
           customUrl


### PR DESCRIPTION
This is supposed to fix #165: When a feed URL is only reachable by https, the subscribe button currently does not work correctly for Overcast, because the scheme `https:` is removed before constructing the Overcast URL. 

This PR transfers the technique already used for cloud URLs to signify whether the scheme should be removed for a client.

I did not find out how I might be able to test this change, so I only followed the code that is already in place. If I can support in testing this before release, then please tell me how.