### PR TITLE
pocket casts needs unencoded url for pcasts.in

### DIFF
--- a/src/coffee/clients.coffee
+++ b/src/coffee/clients.coffee
@@ -57,7 +57,7 @@ class Clients
       scheme: 'http://pcasts.in/feed/'
       icon: 'cloud/pocketcasts.png'
       register: 'https://play.pocketcasts.com/'
-      encodePath: true
+      encodePath: false
     }
   ]
 


### PR DESCRIPTION
pcasts.in doesn't take encoded URLs anymore. Requests with encoded URLs result in a 404.

Example encoded:
https://pcasts.in/feed/ploetz.podigee.io%2Ffeed%2Fmp3

Example not encoded:
https://pcasts.in/feed/ploetz.podigee.io/feed/mp3